### PR TITLE
fix: implement missing KitsapCreator list download

### DIFF
--- a/Urls/KitsapCreator.ps1
+++ b/Urls/KitsapCreator.ps1
@@ -6,8 +6,8 @@ $urls = @{
 
 foreach ($name in $urls.Keys) {
     $url = $urls[$name]
-    $working = "$env:temp\list_${scriptname}_$name.txt"
-    $out = "$env:runningplace\list_${scriptname}_$name.txt"
+    $working = Join-Path ([System.IO.Path]::GetTempPath()) "list_${scriptname}_$name.txt"
+    $out = Join-Path $env:runningplace "list_${scriptname}_$name.txt"
 
     try {
         Invoke-WebRequest -Uri $url -OutFile $working -ErrorAction Stop

--- a/Urls/KitsapCreator.ps1
+++ b/Urls/KitsapCreator.ps1
@@ -1,5 +1,28 @@
-﻿$url=@{
-    ads="https://blocklists.kitsapcreator.com/ads.txt"
-    "gamming-scam" = "https://blocklists.kitsapcreator.com/scam-spam.txt"
+$scriptname = "kitsapcreator"
+$urls = @{
+    "ads"       = "https://blocklists.kitsapcreator.com/ads.txt"
     "scam-spam" = "https://blocklists.kitsapcreator.com/scam-spam.txt"
+}
+
+foreach ($name in $urls.Keys) {
+    $url = $urls[$name]
+    $working = "$env:temp\list_${scriptname}_$name.txt"
+    $out = "$env:runningplace\list_${scriptname}_$name.txt"
+
+    try {
+        Invoke-WebRequest -Uri $url -OutFile $working -ErrorAction Stop
+    } catch {
+        Write-Warning "Failed to download $name list from $url : $_"
+        continue
+    }
+
+    $content = Get-Content -Path $working
+    if (-not $content -or $content.Count -eq 0) {
+        Write-Warning "Downloaded $name list is empty, skipping update"
+        continue
+    }
+
+    ($content | Where-Object { $_.Trim() -ne "" -and $_ -notmatch "^\s*[!#]" }).replace('|', '').replace('^', '') |
+        Sort-Object -Unique |
+        Set-Content -Path $out
 }


### PR DESCRIPTION
Fixes a bug where the KitsapCreator list was never actually downloaded.

Proposed changes in this pull request:
- `Urls/KitsapCreator.ps1` only defined a `$url` hashtable but never called `Invoke-WebRequest`, so despite the README advertising KitsapCreator as an imported list, no `list_*.txt` file was ever produced for it (confirmed via `git log`, the file was never touched since repo creation).
- Implemented the download/merge logic following the same pattern as `hblock.ps1`, looping over each configured list (`ads`, `scam-spam`).
- Removed the duplicate `"gamming-scam"` key (typo, pointed to the same URL as `"scam-spam"`).
- Added basic error handling (try/catch around the download, empty-content guard) so a failed request or an empty response doesn't silently produce an empty/broken list file.

- [x] PR as been tested
- [x] Don't send big changes all at once. Split up big PRs into multiple smaller PRs that are easier to manage and review
- [x] Read [contribution guide](https://github.com/tunisiano187/pi-hole-adblock/blob/master/.github/CONTRIBUTING.md)


---
_Generated by [Claude Code](https://claude.ai/code/session_01SUzADVAtK6C6avWrz45DEs)_