### PR TITLE
fix: remove unused codecov.yml exposing a plaintext token

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,2 +1,0 @@
-﻿codecov:
-  token: f66c71ca-9f1e-465a-baaa-429b723ee57b


### PR DESCRIPTION
Fixes a secret exposure in the repo.

Proposed changes in this pull request:
- Removed `codecov.yml`, which committed a Codecov upload token in plaintext in this public repository.
- Nothing in the project generates or uploads coverage today (no test suite, no coverage step in `au.yml`'s workflow), so the file had no effect and can simply be deleted.

**Note for the maintainer:** the token was already public in git history before this PR, so it's still worth regenerating it from the Codecov dashboard as a precaution — removing the file doesn't purge history.

- [x] PR as been tested
- [x] Don't send big changes all at once. Split up big PRs into multiple smaller PRs that are easier to manage and review
- [x] Read [contribution guide](https://github.com/tunisiano187/pi-hole-adblock/blob/master/.github/CONTRIBUTING.md)


---
_Generated by [Claude Code](https://claude.ai/code/session_01SUzADVAtK6C6avWrz45DEs)_