### PR TITLE
fix: deduplicate all.txt case-insensitively

### DIFF
--- a/start.ps1
+++ b/start.ps1
@@ -17,7 +17,7 @@ foreach ($file in $toadd) {
 }
 git commit -m "[skip ci] update lists"
 
-get-childitem -path "." -include list*.txt -Recurse | ForEach-Object {Get-Content $_; ""} | Sort-Object | get-unique | out-file .\Lists\all.txt
+get-childitem -path "." -include list*.txt -Recurse | ForEach-Object {Get-Content $_; ""} | Where-Object { $_.Trim() -ne "" } | ForEach-Object { $_.ToLowerInvariant() } | Sort-Object -Unique | out-file .\Lists\all.txt
 git add .\Lists\all.txt
 git commit -m "[skip ci] update all.txt"
 


### PR DESCRIPTION
Fixes redundant duplicates in the merged list.

Proposed changes in this pull request:
- `Sort-Object | Get-Unique` in `start.ps1` compares strings case-sensitively by default, so domains differing only by casing (e.g. `Example.com` vs `example.com`) were both kept in `all.txt`, even though they're equivalent for DNS/Pi-hole purposes.
- Lowercase every entry before sorting/deduplicating (`ForEach-Object { $_.ToLowerInvariant() } | Sort-Object -Unique`).
- Also drop blank lines that accumulate between merged list files (each source file is joined with an empty-line separator upstream).

- [x] PR as been tested
- [x] Don't send big changes all at once. Split up big PRs into multiple smaller PRs that are easier to manage and review
- [x] Read [contribution guide](https://github.com/tunisiano187/pi-hole-adblock/blob/master/.github/CONTRIBUTING.md)


---
_Generated by [Claude Code](https://claude.ai/code/session_01SUzADVAtK6C6avWrz45DEs)_