### PR TITLE
fix: don't clobber the hblock list on a failed download

### DIFF
--- a/Urls/hblock.ps1
+++ b/Urls/hblock.ps1
@@ -3,7 +3,18 @@ $scriptname = "hblock"
 $working = "$env:temp\list_$scriptname.txt"
 $out = "$env:runningplace\list_$scriptname.txt"
 
-Invoke-WebRequest -Uri $url -OutFile $working
+try {
+    Invoke-WebRequest -Uri $url -OutFile $working -ErrorAction Stop
+} catch {
+    Write-Warning "Failed to download $scriptname list from $url : $_"
+    return
+}
+
 $content = Get-Content -Path $working
+if (-not $content -or $content.Count -eq 0) {
+    Write-Warning "Downloaded $scriptname list is empty, skipping update"
+    return
+}
+
 ($content | Where-Object {$_ -notmatch "!"}).replace('|','').replace('^','') | Sort-Object | get-unique | Set-Content -Path $out
 


### PR DESCRIPTION
Fixes silent list corruption on download failure.

Proposed changes in this pull request:
- `Invoke-WebRequest` in `hblock.ps1` had no error handling. A transient network failure or a changed upstream URL would either throw mid-run in `start.ps1`, or (on a partial/empty response) silently overwrite `list_hblock.txt` with empty/truncated content that then gets merged straight into `all.txt` and committed.
- Wrapped the download in `try/catch` with a warning on failure.
- Added a guard that skips the update (keeping the last known-good list) if the downloaded content is empty.

- [x] PR as been tested
- [x] Don't send big changes all at once. Split up big PRs into multiple smaller PRs that are easier to manage and review
- [x] Read [contribution guide](https://github.com/tunisiano187/pi-hole-adblock/blob/master/.github/CONTRIBUTING.md)


---
_Generated by [Claude Code](https://claude.ai/code/session_01SUzADVAtK6C6avWrz45DEs)_