### PR TITLE
docs: add usage instructions to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,3 +12,15 @@ The exceptions will create their own lists to be able to choose if you want them
 ## Current lists imported
 - [HBlock](https://hblock.molinero.dev)
 - [KitsapCreator](https://github.com/KitsapCreator/pihole-blocklists)
+
+## Usage
+
+Add the following URL as an adlist in your Pi-hole instance (`Group Management` > `Adlists`):
+
+```
+https://raw.githubusercontent.com/tunisiano187/pi-hole-adblock/main/Lists/all.txt
+```
+
+Then run `Tools` > `Update Gravity` (or `pihole -g` from the command line) to apply it.
+
+The individual source lists (before merging) are also available under [`Lists/`](./Lists) if you only want a subset.


### PR DESCRIPTION
Fills a documentation gap.

Proposed changes in this pull request:
- The README explained what the project does and which source lists it merges, but never told end users the actual thing they need: the raw URL to add as a Pi-hole adlist.
- Added a "Usage" section with the `Lists/all.txt` raw URL and the Pi-hole steps to add/apply it, plus a pointer to the per-source list files for anyone who wants a subset instead of the merged list.

- [x] PR as been tested
- [x] Don't send big changes all at once. Split up big PRs into multiple smaller PRs that are easier to manage and review
- [x] Read [contribution guide](https://github.com/tunisiano187/pi-hole-adblock/blob/master/.github/CONTRIBUTING.md)


---
_Generated by [Claude Code](https://claude.ai/code/session_01SUzADVAtK6C6avWrz45DEs)_