### PR TITLE
feat: add an exclusion list that filters false positives out of all.txt

### DIFF
--- a/Lists/exclusions.txt
+++ b/Lists/exclusions.txt
@@ -1,0 +1,4 @@
+# Domains listed here are removed from the final Lists/all.txt at merge
+# time, even if an upstream source list still blocks them.
+#
+# One domain per line. Lines starting with # are ignored.

--- a/start.ps1
+++ b/start.ps1
@@ -17,7 +17,13 @@ foreach ($file in $toadd) {
 }
 git commit -m "[skip ci] update lists"
 
-get-childitem -path "." -include list*.txt -Recurse | ForEach-Object {Get-Content $_; ""} | Where-Object { $_.Trim() -ne "" } | ForEach-Object { $_.ToLowerInvariant() } | Sort-Object -Unique | out-file ./Lists/all.txt
+$exclusions = [System.Collections.Generic.HashSet[string]]::new([string[]](
+    Get-Content ./Lists/exclusions.txt -ErrorAction SilentlyContinue |
+        ForEach-Object { $_.Trim().ToLowerInvariant() } |
+        Where-Object { $_ -ne "" -and -not $_.StartsWith("#") }
+))
+
+get-childitem -path "." -include list*.txt -Recurse | ForEach-Object {Get-Content $_; ""} | Where-Object { $_.Trim() -ne "" } | ForEach-Object { $_.ToLowerInvariant() } | Where-Object { -not $exclusions.Contains($_) } | Sort-Object -Unique | out-file ./Lists/all.txt
 git add ./Lists/all.txt
 git commit -m "[skip ci] update all.txt"
 


### PR DESCRIPTION
Foundation for a community exclusion-request feature.

Proposed changes in this pull request:
- Added `Lists/exclusions.txt` (one domain per line, `#` comments allowed). The README already described this idea ("add exceptions... to be able to choose if you want them or not") but it was never implemented.
- `start.ps1` now filters these domains out of the merged `Lists/all.txt` during the merge step, using a `HashSet` for O(1) lookups against the ~400k-line merged list (a plain array `-contains` check would be too slow at this size).

This is the foundation for the next PR: a community exclusion-request workflow where contributors propose a domain via an issue, and after automated checks + human review it lands in this file.

- [x] PR as been tested
- [x] Don't send big changes all at once. Split up big PRs into multiple smaller PRs that are easier to manage and review
- [x] Read [contribution guide](https://github.com/tunisiano187/pi-hole-adblock/blob/master/.github/CONTRIBUTING.md)


---
_Generated by [Claude Code](https://claude.ai/code/session_01SUzADVAtK6C6avWrz45DEs)_