### PR TITLE
feat: automate exclusion requests via an issue form + workflow

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -2,7 +2,8 @@
 
 1. [Getting Involved](#getting-involved)
 2. [How To Report Bugs](#how-to-report-bugs)
-3. [Tips For Submitting Code](#tips-for-submitting-code)
+3. [Requesting an Exclusion](#requesting-an-exclusion)
+4. [Tips For Submitting Code](#tips-for-submitting-code)
 
 ## Getting Involved
 
@@ -42,6 +43,16 @@ Please follow these guidelines before reporting a bug:
 3. **Provide a means to reproduce the problem** Please provide as much details as possible, and of course the steps to reproduce the problem.
 
 4. If the above steps are OK and you are sure its a bug, issues are tracked in the [issue tracker](https://github.com/tunisiano187/pi-hole-adblock/issues).
+
+## Requesting an Exclusion
+
+If the merged list blocks something you rely on and it's a false positive, open an
+[Exclusion request](https://github.com/tunisiano187/pi-hole-adblock/issues/new?template=exclusion_request.yml)
+issue with the domain and why it should be excluded.
+
+A workflow automatically checks for duplicates, looks up the domain's reputation, and opens a pull
+request adding it to `Lists/exclusions.txt` for a maintainer to review — you don't need to touch any
+files or open a pull request yourself.
 
 ### Code
 

--- a/.github/ISSUE_TEMPLATE/exclusion_request.yml
+++ b/.github/ISSUE_TEMPLATE/exclusion_request.yml
@@ -1,0 +1,36 @@
+name: Exclusion request
+description: Ask for a domain to be excluded from the merged list because it's a false positive.
+title: "[Exclusion]: "
+labels:
+  - exclusion-request
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Use this form to request that a single domain be excluded from `Lists/all.txt`, for example
+        because it's blocking something you rely on and isn't actually ads/tracking/malware.
+
+        A workflow will automatically check for duplicates, look up the domain's reputation, and
+        open a pull request for a maintainer to review — no need to edit any files yourself.
+  - type: input
+    id: domain
+    attributes:
+      label: Domain or URL to exclude
+      description: A single domain (e.g. `example.com`). If you paste a full URL, only the domain part is used.
+      placeholder: example.com
+    validations:
+      required: true
+  - type: textarea
+    id: reason
+    attributes:
+      label: Why should this be excluded?
+      description: What is it blocking that shouldn't be blocked? Include a link to the affected service/page if you can.
+    validations:
+      required: true
+  - type: checkboxes
+    id: checks
+    attributes:
+      label: Checks
+      options:
+        - label: I searched existing issues and this domain hasn't already been requested.
+          required: true

--- a/.github/workflows/exclusion-request.yml
+++ b/.github/workflows/exclusion-request.yml
@@ -1,0 +1,147 @@
+name: Exclusion Request
+
+on:
+  issues:
+    types: [opened]
+
+permissions:
+  contents: write
+  pull-requests: write
+  issues: write
+
+jobs:
+  process:
+    if: contains(github.event.issue.labels.*.name, 'exclusion-request')
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        shell: pwsh
+    steps:
+      - uses: actions/checkout@v4
+
+      # Untrusted issue content is passed through an env var rather than
+      # interpolated directly into the script, and is never used until it
+      # has been reduced to a strict domain-only regex match below.
+      - name: Extract and validate domain
+        id: extract
+        env:
+          ISSUE_BODY: ${{ github.event.issue.body }}
+        run: |
+          $body = $env:ISSUE_BODY
+          $domain = $null
+
+          if ($body -match '(?ms)###\s*Domain or URL to exclude\s*\r?\n+(?<value>.+?)(\r?\n){2,}###') {
+              $domain = ($matches['value'] -split '\r?\n')[0].Trim()
+          } elseif ($body -match '(?ms)###\s*Domain or URL to exclude\s*\r?\n+(?<value>.+)$') {
+              $domain = ($matches['value'] -split '\r?\n')[0].Trim()
+          }
+
+          if ($domain) {
+              $domain = $domain -replace '^[a-zA-Z]+://', ''
+              $domain = ($domain -split '[/\s]')[0].ToLowerInvariant()
+          }
+
+          $isValid = [bool]$domain -and ($domain -match '^[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?(\.[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?)+$')
+
+          if ($isValid) {
+              "valid=true" >> $env:GITHUB_OUTPUT
+              "domain=$domain" >> $env:GITHUB_OUTPUT
+          } else {
+              "valid=false" >> $env:GITHUB_OUTPUT
+          }
+
+      - name: Comment on unparseable domain
+        if: steps.extract.outputs.valid != 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ISSUE: ${{ github.event.issue.number }}
+        run: |
+          gh issue comment "$env:ISSUE" --body "I couldn't find a valid domain in this issue. Please edit it so the *Domain or URL to exclude* field contains a single domain, e.g. example.com."
+
+      - name: Check for duplicate
+        id: dup
+        if: steps.extract.outputs.valid == 'true'
+        env:
+          DOMAIN: ${{ steps.extract.outputs.domain }}
+        run: |
+          $existing = @()
+          if (Test-Path ./Lists/exclusions.txt) {
+              $existing = Get-Content ./Lists/exclusions.txt | ForEach-Object { $_.Trim().ToLowerInvariant() }
+          }
+          if ($existing -contains $env:DOMAIN) {
+              "duplicate=true" >> $env:GITHUB_OUTPUT
+          } else {
+              "duplicate=false" >> $env:GITHUB_OUTPUT
+          }
+
+      - name: Comment and close on duplicate
+        if: steps.extract.outputs.valid == 'true' && steps.dup.outputs.duplicate == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ISSUE: ${{ github.event.issue.number }}
+          DOMAIN: ${{ steps.extract.outputs.domain }}
+        run: |
+          gh issue comment "$env:ISSUE" --body "$env:DOMAIN is already in the exclusion list. Closing as a duplicate."
+          gh issue close "$env:ISSUE" --reason "not planned"
+
+      - name: Query VirusTotal
+        id: vt
+        if: steps.extract.outputs.valid == 'true' && steps.dup.outputs.duplicate == 'false'
+        env:
+          VT_API_KEY: ${{ secrets.VT_API_KEY }}
+          DOMAIN: ${{ steps.extract.outputs.domain }}
+        run: |
+          if ([string]::IsNullOrEmpty($env:VT_API_KEY)) {
+              "summary=VirusTotal check skipped: no VT_API_KEY secret configured on this repository." >> $env:GITHUB_OUTPUT
+              exit 0
+          }
+
+          try {
+              $resp = Invoke-RestMethod -Uri "https://www.virustotal.com/api/v3/domains/$env:DOMAIN" -Headers @{ "x-apikey" = $env:VT_API_KEY } -ErrorAction Stop
+              $s = $resp.data.attributes.last_analysis_stats
+              $total = $s.malicious + $s.suspicious + $s.harmless + $s.undetected + $s.timeout
+              $summary = "VirusTotal: $($s.malicious) malicious / $($s.suspicious) suspicious / $($s.harmless) harmless / $($s.undetected) undetected (of $total engines) - full report: https://www.virustotal.com/gui/domain/$env:DOMAIN"
+          } catch {
+              $summary = "VirusTotal check failed: $($_.Exception.Message)"
+          }
+
+          $summary = $summary -replace '\r?\n', ' '
+          "summary=$summary" >> $env:GITHUB_OUTPUT
+
+      - name: Create branch and commit
+        id: commit
+        if: steps.extract.outputs.valid == 'true' && steps.dup.outputs.duplicate == 'false'
+        env:
+          DOMAIN: ${{ steps.extract.outputs.domain }}
+          ISSUE: ${{ github.event.issue.number }}
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+          $branch = "exclusion/$env:DOMAIN-issue-$env:ISSUE"
+          git checkout -b $branch
+
+          if (-not (Test-Path ./Lists/exclusions.txt)) {
+              New-Item -ItemType File -Path ./Lists/exclusions.txt | Out-Null
+          }
+          Add-Content -Path ./Lists/exclusions.txt -Value $env:DOMAIN
+          $unique = Get-Content ./Lists/exclusions.txt | Where-Object { $_.Trim() -ne "" } | Sort-Object -Unique
+          Set-Content -Path ./Lists/exclusions.txt -Value $unique
+
+          git add ./Lists/exclusions.txt
+          git commit -m "Add $env:DOMAIN to exclusions (#$env:ISSUE)"
+          git push -u origin $branch
+
+          "branch=$branch" >> $env:GITHUB_OUTPUT
+
+      - name: Open pull request
+        if: steps.extract.outputs.valid == 'true' && steps.dup.outputs.duplicate == 'false'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          DOMAIN: ${{ steps.extract.outputs.domain }}
+          ISSUE: ${{ github.event.issue.number }}
+          BRANCH: ${{ steps.commit.outputs.branch }}
+          VT_SUMMARY: ${{ steps.vt.outputs.summary }}
+        run: |
+          $prBody = "Closes #$env:ISSUE`n`nRequested via the exclusion-request issue form.`n`n$env:VT_SUMMARY`n`nPlease review before merging - this removes $env:DOMAIN from the blocklist for everyone using this project's merged list."
+          gh pr create --title "Exclude $env:DOMAIN" --body $prBody --base main --head $env:BRANCH --label exclusion-request


### PR DESCRIPTION
Adds a self-service path for false-positive reports.

Proposed changes in this pull request:
- `.github/ISSUE_TEMPLATE/exclusion_request.yml`: a GitHub **issue form** (structured YAML, not a freeform markdown template) so the domain field is reliably parseable by automation. Auto-labelled `exclusion-request`.
- `.github/workflows/exclusion-request.yml`: on a new issue carrying that label —
  1. extracts the domain from the issue body and validates it against a strict domain-format regex
  2. checks `Lists/exclusions.txt` for a duplicate (comments + closes the issue if already present)
  3. optionally queries VirusTotal for a reputation summary — **gracefully skipped** if no `VT_API_KEY` secret is configured on the repo, so this works today without any setup and can be strengthened later by adding the secret
  4. opens a pull request adding the domain to `Lists/exclusions.txt`, referencing the issue — **never auto-merged**, always left for a maintainer to review
- `CONTRIBUTING.md`: documents the new flow.

**Security note:** the issue body is untrusted, attacker-controlled text. It's passed into the script via an `env:` var rather than interpolated directly into a `run:` step (the classic GitHub Actions script-injection vector), and nothing derived from it is used in any `git`/`gh` command until it has passed the strict domain-regex validation.

**Depends on #12** (adds `Lists/exclusions.txt`) — the workflow creates the file if it's missing so this PR isn't blocked, but please merge #12 first.

- [x] PR as been tested
- [x] Don't send big changes all at once. Split up big PRs into multiple smaller PRs that are easier to manage and review
- [x] Read [contribution guide](https://github.com/tunisiano187/pi-hole-adblock/blob/master/.github/CONTRIBUTING.md)


---
_Generated by [Claude Code](https://claude.ai/code/session_01SUzADVAtK6C6avWrz45DEs)_