### PR TITLE
feat: automate malicious URL reports via an issue form + workflow

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -2,7 +2,8 @@
 
 1. [Getting Involved](#getting-involved)
 2. [How To Report Bugs](#how-to-report-bugs)
-3. [Tips For Submitting Code](#tips-for-submitting-code)
+3. [Reporting a Malicious URL](#reporting-a-malicious-url)
+4. [Tips For Submitting Code](#tips-for-submitting-code)
 
 ## Getting Involved
 
@@ -42,6 +43,16 @@ Please follow these guidelines before reporting a bug:
 3. **Provide a means to reproduce the problem** Please provide as much details as possible, and of course the steps to reproduce the problem.
 
 4. If the above steps are OK and you are sure its a bug, issues are tracked in the [issue tracker](https://github.com/tunisiano187/pi-hole-adblock/issues).
+
+## Reporting a Malicious URL
+
+Found a domain serving malware, phishing, or a scam that isn't blocked yet? Open a
+[Malicious URL report](https://github.com/tunisiano187/pi-hole-adblock/issues/new?template=malicious_report.yml)
+issue with the domain, where you encountered it, and any supporting evidence.
+
+A workflow automatically checks whether it's already blocked, looks up its reputation, and opens a
+pull request adding it to `Lists/list_community_reported.txt` (including the details you provided)
+for a maintainer to review.
 
 ### Code
 

--- a/.github/ISSUE_TEMPLATE/malicious_report.yml
+++ b/.github/ISSUE_TEMPLATE/malicious_report.yml
@@ -1,0 +1,42 @@
+name: Malicious URL report
+description: Report a domain serving malware, phishing, or scams that isn't blocked yet.
+title: "[Malicious]: "
+labels:
+  - malicious-report
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Use this form to report a single malicious domain so it can be added to the blocklist.
+
+        A workflow will automatically check whether it's already blocked, look up its reputation,
+        and open a pull request (including the details below) for a maintainer to review.
+  - type: input
+    id: domain
+    attributes:
+      label: Malicious domain or URL
+      description: A single domain (e.g. `evil-example.com`). If you paste a full URL, only the domain part is used.
+      placeholder: evil-example.com
+    validations:
+      required: true
+  - type: textarea
+    id: encountered
+    attributes:
+      label: Where/how did you encounter it?
+      description: E.g. a phishing email, a malicious ad, a scam site impersonating a brand...
+    validations:
+      required: true
+  - type: textarea
+    id: evidence
+    attributes:
+      label: Evidence
+      description: Links, screenshots, VirusTotal/urlscan.io reports, or anything else supporting this being malicious.
+    validations:
+      required: false
+  - type: checkboxes
+    id: checks
+    attributes:
+      label: Checks
+      options:
+        - label: I searched existing issues and this domain hasn't already been reported.
+          required: true

--- a/.github/workflows/malicious-report.yml
+++ b/.github/workflows/malicious-report.yml
@@ -1,0 +1,169 @@
+name: Malicious URL Report
+
+on:
+  issues:
+    types: [opened]
+
+permissions:
+  contents: write
+  pull-requests: write
+  issues: write
+
+jobs:
+  process:
+    if: contains(github.event.issue.labels.*.name, 'malicious-report')
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        shell: pwsh
+    steps:
+      - uses: actions/checkout@v4
+
+      # Untrusted issue content is passed through an env var rather than
+      # interpolated directly into the script, and is never used until it
+      # has been reduced to a strict domain-only regex match below.
+      - name: Extract and validate domain
+        id: extract
+        env:
+          ISSUE_BODY: ${{ github.event.issue.body }}
+        run: |
+          $body = $env:ISSUE_BODY
+          $domain = $null
+
+          if ($body -match '(?ms)###\s*Malicious domain or URL\s*\r?\n+(?<value>.+?)(\r?\n){2,}###') {
+              $domain = ($matches['value'] -split '\r?\n')[0].Trim()
+          } elseif ($body -match '(?ms)###\s*Malicious domain or URL\s*\r?\n+(?<value>.+)$') {
+              $domain = ($matches['value'] -split '\r?\n')[0].Trim()
+          }
+
+          if ($domain) {
+              $domain = $domain -replace '^[a-zA-Z]+://', ''
+              $domain = ($domain -split '[/\s]')[0].ToLowerInvariant()
+          }
+
+          $isValid = [bool]$domain -and ($domain -match '^[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?(\.[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?)+$')
+
+          if ($isValid) {
+              "valid=true" >> $env:GITHUB_OUTPUT
+              "domain=$domain" >> $env:GITHUB_OUTPUT
+          } else {
+              "valid=false" >> $env:GITHUB_OUTPUT
+          }
+
+      - name: Comment on unparseable domain
+        if: steps.extract.outputs.valid != 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ISSUE: ${{ github.event.issue.number }}
+        run: |
+          gh issue comment "$env:ISSUE" --body "I couldn't find a valid domain in this issue. Please edit it so the *Malicious domain or URL* field contains a single domain, e.g. evil-example.com."
+
+      - name: Check if already blocked
+        id: dup
+        if: steps.extract.outputs.valid == 'true'
+        env:
+          DOMAIN: ${{ steps.extract.outputs.domain }}
+        run: |
+          $existing = @()
+          if (Test-Path ./Lists/all.txt) {
+              $existing = Get-Content ./Lists/all.txt
+          }
+          if ($existing -contains $env:DOMAIN) {
+              "duplicate=true" >> $env:GITHUB_OUTPUT
+          } else {
+              "duplicate=false" >> $env:GITHUB_OUTPUT
+          }
+
+      - name: Comment and close if already blocked
+        if: steps.extract.outputs.valid == 'true' && steps.dup.outputs.duplicate == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ISSUE: ${{ github.event.issue.number }}
+          DOMAIN: ${{ steps.extract.outputs.domain }}
+        run: |
+          gh issue comment "$env:ISSUE" --body "$env:DOMAIN is already blocked in Lists/all.txt. Thanks for double-checking - closing as a duplicate."
+          gh issue close "$env:ISSUE" --reason "not planned"
+
+      - name: Query VirusTotal
+        id: vt
+        if: steps.extract.outputs.valid == 'true' && steps.dup.outputs.duplicate == 'false'
+        env:
+          VT_API_KEY: ${{ secrets.VT_API_KEY }}
+          DOMAIN: ${{ steps.extract.outputs.domain }}
+        run: |
+          if ([string]::IsNullOrEmpty($env:VT_API_KEY)) {
+              "summary=VirusTotal check skipped: no VT_API_KEY secret configured on this repository." >> $env:GITHUB_OUTPUT
+              exit 0
+          }
+
+          try {
+              $resp = Invoke-RestMethod -Uri "https://www.virustotal.com/api/v3/domains/$env:DOMAIN" -Headers @{ "x-apikey" = $env:VT_API_KEY } -ErrorAction Stop
+              $s = $resp.data.attributes.last_analysis_stats
+              $total = $s.malicious + $s.suspicious + $s.harmless + $s.undetected + $s.timeout
+              $summary = "VirusTotal: $($s.malicious) malicious / $($s.suspicious) suspicious / $($s.harmless) harmless / $($s.undetected) undetected (of $total engines) - full report: https://www.virustotal.com/gui/domain/$env:DOMAIN"
+          } catch {
+              $summary = "VirusTotal check failed: $($_.Exception.Message)"
+          }
+
+          $summary = $summary -replace '\r?\n', ' '
+          "summary=$summary" >> $env:GITHUB_OUTPUT
+
+      - name: Create branch, commit and open pull request
+        if: steps.extract.outputs.valid == 'true' && steps.dup.outputs.duplicate == 'false'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ISSUE_BODY: ${{ github.event.issue.body }}
+          ISSUE: ${{ github.event.issue.number }}
+          DOMAIN: ${{ steps.extract.outputs.domain }}
+          VT_SUMMARY: ${{ steps.vt.outputs.summary }}
+        run: |
+          function Get-FormField {
+              param([string]$Body, [string]$Label)
+              $escaped = [regex]::Escape($Label)
+              if ($Body -match "(?ms)###\s*$escaped\s*\r?\n+(?<value>.+?)(\r?\n){2,}###") {
+                  return $matches['value'].Trim()
+              } elseif ($Body -match "(?ms)###\s*$escaped\s*\r?\n+(?<value>.+)$") {
+                  return $matches['value'].Trim()
+              }
+              return ""
+          }
+
+          $encountered = Get-FormField -Body $env:ISSUE_BODY -Label "Where/how did you encounter it?"
+          $evidence = Get-FormField -Body $env:ISSUE_BODY -Label "Evidence"
+          if ([string]::IsNullOrWhiteSpace($evidence) -or $evidence -match '^_No response_$') { $evidence = "_none provided_" }
+          if ([string]::IsNullOrWhiteSpace($encountered) -or $encountered -match '^_No response_$') { $encountered = "_none provided_" }
+
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+          $branch = "malicious/$env:DOMAIN-issue-$env:ISSUE"
+          git checkout -b $branch
+
+          if (-not (Test-Path ./Lists/list_community_reported.txt)) {
+              New-Item -ItemType File -Path ./Lists/list_community_reported.txt | Out-Null
+          }
+          Add-Content -Path ./Lists/list_community_reported.txt -Value $env:DOMAIN
+          $unique = Get-Content ./Lists/list_community_reported.txt | Where-Object { $_.Trim() -ne "" } | Sort-Object -Unique
+          Set-Content -Path ./Lists/list_community_reported.txt -Value $unique
+
+          git add ./Lists/list_community_reported.txt
+          git commit -m "Add $env:DOMAIN to community-reported list (#$env:ISSUE)"
+          git push -u origin $branch
+
+          $prBody = @"
+          Closes #$env:ISSUE
+
+          Reported via the malicious-report issue form.
+
+          $env:VT_SUMMARY
+
+          **Where/how it was encountered:**
+          $encountered
+
+          **Evidence:**
+          $evidence
+
+          Please review before merging - this adds $env:DOMAIN to the blocklist for everyone using this project's merged list.
+          "@
+          Set-Content -Path pr-body.md -Value $prBody
+          gh pr create --title "Block $env:DOMAIN" --body-file pr-body.md --base main --head $branch --label malicious-report


### PR DESCRIPTION
Adds a self-service path for the community to flag domains that should be blocked but aren't.

Proposed changes in this pull request:
- `.github/ISSUE_TEMPLATE/malicious_report.yml`: a GitHub issue form (domain, where it was encountered, evidence), auto-labelled `malicious-report`.
- `Lists/list_community_reported.txt`: new (empty) source list, automatically merged into `Lists/all.txt` by `start.ps1` — it already picks up any `list*.txt` file, no merge-script changes needed.
- `.github/workflows/malicious-report.yml`: on a new issue carrying that label —
  1. extracts and regex-validates the domain
  2. checks whether it's already in `Lists/all.txt` (comments + closes the issue if so)
  3. optionally queries VirusTotal — gracefully skipped if no `VT_API_KEY` secret is configured
  4. opens a pull request adding the domain, **quoting the reporter's "where encountered" and "evidence" answers in the PR body** for context — never auto-merged, always left for a maintainer to review
- `CONTRIBUTING.md`: documents the new flow.

Same script-injection mitigation as #13 (exclusion-request workflow): the issue body only ever reaches the script via an `env:` var, and nothing derived from it touches `git`/`gh` until the domain has passed strict regex validation.

Independent of #12/#13 — doesn't touch `Lists/exclusions.txt`.

- [x] PR as been tested
- [x] Don't send big changes all at once. Split up big PRs into multiple smaller PRs that are easier to manage and review
- [x] Read [contribution guide](https://github.com/tunisiano187/pi-hole-adblock/blob/master/.github/CONTRIBUTING.md)


---
_Generated by [Claude Code](https://claude.ai/code/session_01SUzADVAtK6C6avWrz45DEs)_