### PR TITLE
feat: add URLhaus as a new blocklist source

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ The exceptions will create their own lists to be able to choose if you want them
 ## Current lists imported
 - [HBlock](https://hblock.molinero.dev)
 - [KitsapCreator](https://github.com/KitsapCreator/pihole-blocklists)
+- [URLhaus](https://urlhaus.abuse.ch) (active malware-distribution domains)
 
 ## Usage
 

--- a/Urls/urlhaus.ps1
+++ b/Urls/urlhaus.ps1
@@ -1,0 +1,21 @@
+$url = "https://urlhaus.abuse.ch/downloads/hostfile/"
+$scriptname = "urlhaus"
+$working = Join-Path ([System.IO.Path]::GetTempPath()) "list_$scriptname.txt"
+$out = Join-Path $env:runningplace "list_$scriptname.txt"
+
+try {
+    Invoke-WebRequest -Uri $url -OutFile $working -ErrorAction Stop
+} catch {
+    Write-Warning "Failed to download $scriptname list from $url : $_"
+    return
+}
+
+$content = Get-Content -Path $working
+if (-not $content -or $content.Count -eq 0) {
+    Write-Warning "Downloaded $scriptname list is empty, skipping update"
+    return
+}
+
+($content | Where-Object { $_.Trim() -ne "" -and $_ -notmatch "^\s*#" }) -replace '^0\.0\.0\.0\s+', '' |
+    Sort-Object -Unique |
+    Set-Content -Path $out


### PR DESCRIPTION
Broadens list coverage as discussed.

Proposed changes in this pull request:
- Added `Urls/urlhaus.ps1`, downloading [URLhaus](https://urlhaus.abuse.ch)'s plaintext hosts-format feed of domains actively distributing malware (no API key required), following the same download/merge pattern as `hblock.ps1` (error handling included from the start).
- Updated the README's list of imported sources.

This is a good complement to the new malicious-URL community reporting workflow (#14) — one covers automated threat-intel feeds, the other covers community tips.

Other candidates worth considering later if useful (not included here, since they involve editorial tradeoffs like list size/aggressiveness the maintainer should pick): OISD, StevenBlack's hosts, 1Hosts.

- [x] PR as been tested
- [x] Don't send big changes all at once. Split up big PRs into multiple smaller PRs that are easier to manage and review
- [x] Read [contribution guide](https://github.com/tunisiano187/pi-hole-adblock/blob/master/.github/CONTRIBUTING.md)


---
_Generated by [Claude Code](https://claude.ai/code/session_01SUzADVAtK6C6avWrz45DEs)_