### PR TITLE
fix: don't crash the merge when exclusions.txt has no active entries

### DIFF
--- a/start.ps1
+++ b/start.ps1
@@ -17,11 +17,12 @@ foreach ($file in $toadd) {
 }
 git commit -m "[skip ci] update lists"
 
-$exclusions = [System.Collections.Generic.HashSet[string]]::new([string[]](
+$exclusionLines = @(
     Get-Content ./Lists/exclusions.txt -ErrorAction SilentlyContinue |
         ForEach-Object { $_.Trim().ToLowerInvariant() } |
         Where-Object { $_ -ne "" -and -not $_.StartsWith("#") }
-))
+)
+$exclusions = [System.Collections.Generic.HashSet[string]]::new([string[]]$exclusionLines)
 
 get-childitem -path "." -include list*.txt -Recurse | ForEach-Object {Get-Content $_; ""} | Where-Object { $_.Trim() -ne "" } | ForEach-Object { $_.ToLowerInvariant() } | Where-Object { -not $exclusions.Contains($_) } | Sort-Object -Unique | out-file ./Lists/all.txt
 git add ./Lists/all.txt


### PR DESCRIPTION
Fixes the "Auto Update" workflow failures reported just now.

Root cause: `Lists/exclusions.txt` currently only contains header comments (no exclusion has been approved yet), so the filtering pipeline produced zero output objects. In PowerShell, a pipeline that emits zero objects evaluates to `$null` when assigned directly (not an empty array), so `[HashSet[string]]::new([string[]]$null)` threw and left `$exclusions` unassigned. Every subsequent `$exclusions.Contains($_)` call in the merge step then failed with "You cannot call a method on a null-valued expression" — once per line of the ~440k-line merged list.

**Good news:** the resulting (mostly emptied-out) `all.txt` got committed locally in those failed runs, but the `git push` was rejected each time (stale ref from concurrent runs), so the corrupted list never reached `origin/main` — `Lists/all.txt` on `main` is still intact at 527k lines.

Fix: wrap the filter pipeline in `@(...)`, which always forces an array (empty or not), so the crash can't happen regardless of how many exclusions currently exist.

- [x] PR as been tested
- [x] Don't send big changes all at once. Split up big PRs into multiple smaller PRs that are easier to manage and review
- [x] Read [contribution guide](https://github.com/tunisiano187/pi-hole-adblock/blob/master/.github/CONTRIBUTING.md)


---
_Generated by [Claude Code](https://claude.ai/code/session_01SUzADVAtK6C6avWrz45DEs)_