### PR TITLE
Exclude technocite.be

### DIFF
--- a/Lists/exclusions.txt
+++ b/Lists/exclusions.txt
@@ -2,3 +2,4 @@
 # time, even if an upstream source list still blocks them.
 #
 # One domain per line. Lines starting with # are ignored.
+technocite.be


### PR DESCRIPTION
Closes #17

Requested via the exclusion-request issue form. Processed manually because the automated workflow didn't fire — see the separate fix incoming for why (missing repo label, now created).

VirusTotal check skipped: no VT_API_KEY secret configured on this repository.

Please review before merging - this removes technocite.be from the blocklist for everyone using this project's merged list.


---
_Generated by [Claude Code](https://claude.ai/code/session_01SUzADVAtK6C6avWrz45DEs)_