### PR TITLE
fix: don't rely on issue-form labels existing in the repo

### DIFF
--- a/.github/workflows/exclusion-request.yml
+++ b/.github/workflows/exclusion-request.yml
@@ -11,7 +11,10 @@ permissions:
 
 jobs:
   process:
-    if: contains(github.event.issue.labels.*.name, 'exclusion-request')
+    # GitHub issue forms silently drop the `labels:` field if that label
+    # doesn't already exist in the repo (it is not auto-created), so also
+    # match on the title prefix the form always sets as a fallback.
+    if: contains(github.event.issue.labels.*.name, 'exclusion-request') || startsWith(github.event.issue.title, '[Exclusion]:')
     runs-on: ubuntu-latest
     defaults:
       run:
@@ -144,4 +147,6 @@ jobs:
           VT_SUMMARY: ${{ steps.vt.outputs.summary }}
         run: |
           $prBody = "Closes #$env:ISSUE`n`nRequested via the exclusion-request issue form.`n`n$env:VT_SUMMARY`n`nPlease review before merging - this removes $env:DOMAIN from the blocklist for everyone using this project's merged list."
-          gh pr create --title "Exclude $env:DOMAIN" --body $prBody --base main --head $env:BRANCH --label exclusion-request
+          gh pr create --title "Exclude $env:DOMAIN" --body $prBody --base main --head $env:BRANCH
+          # Best-effort: don't fail PR creation just because the label doesn't exist (yet) in this repo.
+          gh pr edit "$env:BRANCH" --add-label exclusion-request 2>$null

--- a/.github/workflows/malicious-report.yml
+++ b/.github/workflows/malicious-report.yml
@@ -11,7 +11,10 @@ permissions:
 
 jobs:
   process:
-    if: contains(github.event.issue.labels.*.name, 'malicious-report')
+    # GitHub issue forms silently drop the `labels:` field if that label
+    # doesn't already exist in the repo (it is not auto-created), so also
+    # match on the title prefix the form always sets as a fallback.
+    if: contains(github.event.issue.labels.*.name, 'malicious-report') || startsWith(github.event.issue.title, '[Malicious]:')
     runs-on: ubuntu-latest
     defaults:
       run:
@@ -166,4 +169,6 @@ jobs:
           Please review before merging - this adds $env:DOMAIN to the blocklist for everyone using this project's merged list.
           "@
           Set-Content -Path pr-body.md -Value $prBody
-          gh pr create --title "Block $env:DOMAIN" --body-file pr-body.md --base main --head $branch --label malicious-report
+          gh pr create --title "Block $env:DOMAIN" --body-file pr-body.md --base main --head $branch
+          # Best-effort: don't fail PR creation just because the label doesn't exist (yet) in this repo.
+          gh pr edit $branch --add-label malicious-report 2>$null


### PR DESCRIPTION
Fixes why issue #17 skipped both workflows.

Root cause: GitHub issue forms silently drop the `labels:` field if that label doesn't already exist in the repository — it is **not** auto-created. Neither `exclusion-request` nor `malicious-report` existed as repo labels, so issue #17 (opened via the exclusion-request template) ended up with zero labels, and both workflows' `if: contains(..., 'label')` conditions evaluated false — the jobs showed as skipped.

I've already created both labels directly on this repo as a one-time fix, and manually processed #17 (see #18). This PR fixes the underlying fragility so it can't silently happen again (e.g. on a fresh fork where the labels don't exist yet):

- Trigger condition now also matches the title prefix the issue form always sets (`[Exclusion]:` / `[Malicious]:`), which doesn't depend on any label existing.
- PR creation no longer passes `--label` directly, since a missing label would fail that whole step (and the branch/commit would be pushed with no PR to show for it). It now creates the PR first, then best-effort adds the label via a separate `gh pr edit ... --add-label` call that can't block the PR itself.

- [x] PR as been tested
- [x] Don't send big changes all at once. Split up big PRs into multiple smaller PRs that are easier to manage and review
- [x] Read [contribution guide](https://github.com/tunisiano187/pi-hole-adblock/blob/master/.github/CONTRIBUTING.md)


---
_Generated by [Claude Code](https://claude.ai/code/session_01SUzADVAtK6C6avWrz45DEs)_